### PR TITLE
Pass the url params for the view as context to the view.

### DIFF
--- a/Controller/SourceController.php
+++ b/Controller/SourceController.php
@@ -3,6 +3,7 @@
 namespace Revinate\AnalyticsBundle\Controller;
 
 use Revinate\AnalyticsBundle\AnalyticsInterface;
+use Revinate\AnalyticsBundle\Analytics;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -45,7 +46,8 @@ class SourceController extends Controller {
         $sourceConfig = $config['sources'][$source];
         /** @var AnalyticsInterface $analytics */
         $analytics = new $sourceConfig['class']($this->get('service_container'));
-        if (method_exists($analytics, 'setContext')) {
+        if ($analytics instanceof Analytics) {
+            /** @var Analytics $analytics */
             /** @var Request $request */
             $request = $this->get('request_stack')->getMasterRequest();
             $params = $request->query->all();

--- a/Controller/SourceController.php
+++ b/Controller/SourceController.php
@@ -7,7 +7,7 @@ use Revinate\AnalyticsBundle\AnalyticsInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\HttpFoundation\JsonResponse;
-
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class SourceController extends Controller {
@@ -45,6 +45,12 @@ class SourceController extends Controller {
         $sourceConfig = $config['sources'][$source];
         /** @var AnalyticsInterface $analytics */
         $analytics = new $sourceConfig['class']($this->get('service_container'));
+        if (method_exists($analytics, 'setContext')) {
+            /** @var Request $request */
+            $request = $this->get('request_stack')->getMasterRequest();
+            $params = $request->query->all();
+            $analytics->setContext($params);
+        }
         $data = array_merge(
             $analytics->getConfig(),
             array('_links' => $this->getLinks($analytics, $source))

--- a/Test/Entity/ViewAnalytics.php
+++ b/Test/Entity/ViewAnalytics.php
@@ -54,6 +54,7 @@ class ViewAnalytics extends Analytics {
     public function getMetrics()
     {
         $dollarToRupeeConversionRate = $this->getContextValue("dollarToRupeeConversionRate");
+        $activeBrowser = $this->getContextValue("browser");
         return array(
             Metric::create("totalViews", "views")->setResult(Result::SUM),
             Metric::create("uniqueViews", "views")->setResult(Result::COUNT),
@@ -73,6 +74,7 @@ class ViewAnalytics extends Analytics {
                 return $chromeAndIe6Views * 0.05;
             })->setPrecision(2),
             Metric::create("chromeTotalViews", "views")->setFilter(FilterHelper::getValueFilter("browser", "chrome"))->setResult(Result::SUM),
+            Metric::create("browserTotalViews", "views")->setFilter(FilterHelper::getValueFilter("browser", $activeBrowser))->setResult(Result::SUM)->setReadableName("Total Views For $activeBrowser"),
             Metric::create("ie6TotalViews", "views")->setFilter(FilterHelper::getValueFilter("browser", "ie6"))->setResult(Result::SUM),
             Metric::create("averageViews", "views")->setResult(Result::AVG),
             Metric::create("averageWeightage", "tags.weightage")->setNestedPath("tags")->setResult(Result::AVG),

--- a/Test/TestCase/Controller/ApiControllerTest.php
+++ b/Test/TestCase/Controller/ApiControllerTest.php
@@ -44,6 +44,12 @@ class ApiControllerTest extends BaseTestCase
         $this->assertTrue(!empty($response['metrics']), $this->debug($response));
     }
 
+    public function testListSourceApiWithParams() {
+        $this->client->request("GET", "/api/analytics/source/view?browser=firefox");
+        $content = $this->client->getResponse()->getContent();
+        $this->assertContains('Total Views For firefox', $content);
+    }
+
     public function testStatsSourceApi() {
         $this->createData();
         $post = json_encode(array(


### PR DESCRIPTION
Passing along the `get` params from the url as context to the view is necessary to filter the list of possible dimensions, metrics, and filters returned.